### PR TITLE
Add datadog copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2021 Mikhail Shapirov
+Copyright [2022-Present] Datadog, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Add `Copyright [2022-Present] Datadog, Inc.` to the project license.