### PR TITLE
Fix yarn publish for initial creation

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -12,6 +12,6 @@ jobs:
           node-version: '16.x'
       - run: |
           yarn
-          yarn publish --tag=beta
+          yarn publish --access=public --tag=beta
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
The `--access=public` is required for initial package creation