### PR TITLE
add installInfo to helm values for install tracking

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,6 +3,7 @@ import { Construct } from 'constructs';
 import { ClusterInfo } from "@aws-quickstart/eks-blueprints/dist/spi";
 import { HelmAddOn, HelmAddOnProps, HelmAddOnUserProps } from '@aws-quickstart/eks-blueprints/dist/addons/helm-addon';
 import { getSecretValue } from "@aws-quickstart/eks-blueprints/dist/utils";
+import { version as addonVersion } from '../package.json';
 
 export interface DatadogAddOnProps extends HelmAddOnUserProps {
     /**
@@ -79,7 +80,12 @@ export class DatadogAddOn extends HelmAddOn {
                 apiKey: apiKeyValue ? apiKeyValue : this.options.apiKey,
                 appKey: appKeyValue ? appKeyValue : this.options.appKey,
                 apiKeyExistingSecret: this.options.apiKeyExistingSecret,
-                appKeyExistingSecret: this.options.appKeyExistingSecret
+                appKeyExistingSecret: this.options.appKeyExistingSecret,
+                installInfo: {
+                    tool: 'eks-blueprints-addon',
+                    toolVersion: addonVersion,
+                    installerVersion: this.options.version ?? defaultProps.version,
+                }
             }
         }, this.options.values ?? {})
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
         "inlineSources": true,
         "experimentalDecorators": true,
         "strictPropertyInitialization": false,
+        "resolveJsonModule": true,
         "typeRoots": [
             "./node_modules/@types"
         ]


### PR DESCRIPTION
## What does this PR do?

Injects `datadog.installInfo` into the Helm values so the agent's `install_info` file identifies the installation as coming from the EKS Blueprints AddOn rather than generic Helm.

The agent writes this to `/etc/datadog-agent/install_info` and sends it in host metadata, which lets the Datadog backend attribute the installation method correctly.

- `tool`: `eks-blueprints-addon`
- `toolVersion`: read from `package.json` at runtime -- stays accurate across releases automatically
- `installerVersion`: the Helm chart version in use (user-configured or the addon default)

Also enables `resolveJsonModule` in `tsconfig.json` to support the `package.json` import.

## Dependency

This is gated on a companion PR to [DataDog/helm-charts](https://github.com/DataDog/helm-charts) to make `installInfo.tool` and `installInfo.toolVersion` configurable via values (currently hardcoded to `helm` / `Helm` in `install_info-configmap.yaml`). The values injected here are silently ignored by the current chart -- they take effect once that chart PR merges.

## Test plan

- [ ] CI build passes
- [ ] Verify `datadog.installInfo` appears correctly in rendered Helm values once the helm-charts PR is available